### PR TITLE
修复 Gradle 构建时的报错

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<build>
 		<resources>
 			<resource>
-				<directory></directory>
+				<directory>./</directory>
 				<includes>
 					<include>COPYING</include>
 					<include>LICENSE</include>


### PR DESCRIPTION
修复 Gradle 构建时报 "'build.resources.resource.directory' is missing" 的问题